### PR TITLE
prebuilt-libwebp v0.0.12 - (libwebp version v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [0.0.12]
+
+- libwebp tag v1.3.2
+
 ## [0.0.11]
 
 - libwebp tag v1.3.1

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'zip'
 require 'digest/md5'
 
 GIT_ROOT = `git rev-parse --show-toplevel`.strip
-VERSION = 'v1.3.1'
+VERSION = 'v1.3.2'
 LIBWEBP = "libwebp"
 
 desc "default"


### PR DESCRIPTION
Update build script to v1.3.2. Fix for Critical WebP 0-day security issue CVE-2023-4863.

Universal Binary Build successfully tested on macOS 14.0 Sonoma.